### PR TITLE
fix: Don't decorate with a reference type per Fastify deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class FastifyMetricsJSResponseTiming {
 
     plugin() {
         return fp((fastify, opts, done) => {
-            fastify.decorateRequest('timingMetrics', {});
+            fastify.decorateRequest('timingMetrics', null);
 
             fastify.addHook('onRequest', (request, reply, next) => {
                 if (


### PR DESCRIPTION
```
(node:15498) [FSTDEP006] FastifyDeprecation: You are decorating Request/Reply with a reference type. This reference is shared amongst all requests. Use onRequest hook instead. Property: timingMetrics
```