### PR TITLE
feat: support newer versions of fastify. Convert to ESM

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     ],
     "class-methods-use-this": [
       0
-    ]
+    ],
+    "import/extensions": [0]
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Fastify plugin for generating @metrics/client (https://www.npmjs.com/package/@
 Step 1. Include and setup dependency
 
 ```js
-const ResponseTiming = require('fastify-metrics-js-response-timing');
+import ResponseTiming from 'fastify-metrics-js-response-timing';
 const reponseTiming = new ResponseTiming();
 ```
 
@@ -20,7 +20,8 @@ responseTiming.metrics.pipe(consumer);
 Step 3. Create a fastify app and include the plugin
 
 ```js
-const app = require('fastify')();
+import fastify from 'fastify';
+const app = fastify();
 app.register(responseTiming.plugin());
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const fp = require('fastify-plugin');
-const Metrics = require('@metrics/client');
+import fp from 'fastify-plugin';
+import Metrics from '@metrics/client';
 
 class FastifyMetricsJSResponseTiming {
     constructor({ groupStatusCodes = false, timeAllRoutes = true } = {}) {
@@ -57,7 +57,7 @@ class FastifyMetricsJSResponseTiming {
             });
 
             fastify.addHook('onResponse', (request, reply, next) => {
-                if (request.timingMetrics.histogram) {
+                if (request?.timingMetrics?.histogram) {
                     const { method } = request.raw;
                     const statusCode = this.groupStatusCodes
                         ? `${Math.floor(reply.raw.statusCode / 100)}xx`
@@ -76,10 +76,9 @@ class FastifyMetricsJSResponseTiming {
 
             done();
         },{
-            fastify: '^3.0.0',
             name: 'fastify-metrics-js-response-timing',
         });
     }
 }
 
-module.exports = FastifyMetricsJSResponseTiming;
+export default FastifyMetricsJSResponseTiming;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "A Fastify plugin using @metrics/client (https://www.npmjs.com/package/@metrics/client) to produce metric streams reporting metrics about route response times",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "tap",
     "lint:format": "eslint --fix .",
@@ -20,18 +21,18 @@
   },
   "homepage": "https://github.com/finn-no/fastify-metrics-js-response-timing#readme",
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint": "^8.34.0",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^6.9.0",
-    "eslint-plugin-import": "^2.20.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "fastify": "3.2.1",
-    "prettier": "^1.19.1",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-prettier": "^4.2.1",
+    "fastify": "^3.2.1",
+    "prettier": "^2.8.4",
     "supertest": "^4.0.2",
-    "tap": "^14.10.6"
+    "tap": "^16.3.4"
   },
   "dependencies": {
-    "@metrics/client": "2.5.0",
-    "fastify-plugin": "2.3.0"
+    "@metrics/client": "^2.5.0",
+    "fastify-plugin": "^4.5.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const { test } = require('tap');
-const fastify = require('fastify');
-const supertest = require('supertest');
-const Plugin = require('./index');
+import { test } from 'tap';
+import fastify from 'fastify';
+import supertest from 'supertest';
+import Plugin from './index.js';
 
 test('timeAllRoutes = false: No metrics are generated when route url config is not explicitly defined', async t => {
     const app = fastify();
@@ -12,7 +10,7 @@ test('timeAllRoutes = false: No metrics are generated when route url config is n
     app.get('/my-route', (request, reply) => {
         reply.send('');
     });
-    const address = await app.listen();
+    const address = await app.listen({ port: 0 });
 
     const buffer = [];
 
@@ -44,7 +42,7 @@ test('timeAllRoutes = false: Plugin generates expected histogram metric for rout
             reply.send('');
         },
     );
-    const address = await app.listen();
+    const address = await app.listen({ port: 0 });
 
     const buffer = [];
 
@@ -96,7 +94,7 @@ test('timeAllRoutes = true: Metrics are generated when route url config is not e
     app.get('/my-route', (request, reply) => {
         reply.send('');
     });
-    const address = await app.listen();
+    const address = await app.listen({ port: 0 });
 
     const buffer = [];
 
@@ -148,7 +146,7 @@ test('timeAllRoutes = true: No metrics are generated when route url config is ex
     app.get('/my-route', { config: { timing: false } }, (request, reply) => {
         reply.send('');
     });
-    const address = await app.listen();
+    const address = await app.listen({ port: 0 });
 
     const buffer = [];
 


### PR DESCRIPTION
BREAKING CHANGE: Module now ESM only

This removes the Fastify plugin param that locks the module to a specific version of fastify. I have never seen this be useful and we have quite a few modules now that need to be updated to deal with this value being out of date so I propose we just remove it.